### PR TITLE
This line triggered the _scheduleResume function even when the networ…

### DIFF
--- a/modules/xmpp/ResumeTask.js
+++ b/modules/xmpp/ResumeTask.js
@@ -69,7 +69,6 @@ export default class ResumeTask {
                     }
                 });
 
-        NetworkInfo.isOnline() && this._scheduleResume();
     }
 
     /**


### PR DESCRIPTION
…k was offline.

This line triggered the _scheduleResume function even when the network was offline. Given the presence of the listener mechanism, this line is redundant and its removal is recommended to avoid unnecessary operations.